### PR TITLE
add WLivi to contributors.json

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -673,5 +673,17 @@
 		"Contributions": {
 			"YARG": [ "Developer" ]
 		}
+	},
+	{
+		"Name": "WLivi",
+		"Socials": {
+			"Twitch": "W_Livi",
+			"Github": "W-Livi",
+			"Discord": "wlivi",
+			"VideoService": "@WLivi"
+		},
+		"Contributions": {
+			"YARG": [ "Developer" ]
+		}
 	}
 ]


### PR DESCRIPTION
While they were small, I did commit a couple of changes earlier this year.
If this list ever adds a Documentation contrib type, or social links out to Fediverse or Bluesky, I'll probably wanna swing back and revise my entry.